### PR TITLE
yazi: update

### DIFF
--- a/apps/core/yazi/keybinds.nix
+++ b/apps/core/yazi/keybinds.nix
@@ -19,7 +19,7 @@ in
     {
       desc = "Move cursor to the bottom";
       on = [ "g" "G" ];
-      run = "arrow 99999999";
+      run = "arrow bot";
     }
 
     {

--- a/apps/core/yazi/smart-paste.nix
+++ b/apps/core/yazi/smart-paste.nix
@@ -8,7 +8,7 @@
     run = "plugin smart-paste";
   };
 
-  hm.xdg.configFile."yazi/plugins/smart-paste.yazi/init.lua".text =
+  hm.xdg.configFile."yazi/plugins/smart-paste.yazi/main.lua".text =
   /* lua */
   ''
     --- @sync entry

--- a/apps/core/yazi/storecwd.nix
+++ b/apps/core/yazi/storecwd.nix
@@ -10,7 +10,7 @@
 
   # Store the current working directory when we suspend Yazi
   # From https://github.com/Axlefublr/dotfiles/blob/38525a7f900709efe5d0ea3005b670203626794d/yazi/plugins/storecwd.yazi/init.lua#L5
-  hm.xdg.configFile."yazi/plugins/storecwd.yazi/init.lua".text =
+  hm.xdg.configFile."yazi/plugins/storecwd.yazi/main.lua".text =
   /* lua */
   ''
     --- @sync entry

--- a/apps/core/yazi/yazi-plugins.nix
+++ b/apps/core/yazi/yazi-plugins.nix
@@ -1,10 +1,16 @@
-{ inputs, ... }:
+{ inputs, lib, ... }:
 
 let
   plugins = inputs.yazi-plugins;
 
 in
 {
+  hm = # Use unstable home-manager module for compatibility with Yazi package update
+  {
+    disabledModules = lib.singleton "${inputs.home-manager}/modules/programs/yazi.nix";
+    imports = lib.singleton "${inputs.home-manager-unstable}/modules/programs/yazi.nix";
+  };
+
   hm.programs.yazi.plugins =
   {
     jump-to-char = plugins + "/jump-to-char.yazi";

--- a/flake.lock
+++ b/flake.lock
@@ -11,11 +11,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1738901016,
-        "narHash": "sha256-951N/EZZnq4+TmTV7jWBEQyjAdZ7f+jmfTrF6OgNe9o=",
+        "lastModified": 1739003331,
+        "narHash": "sha256-GVcw+qO4cNHG1kjvw2Jy3341Xe4w0jRzjQ2awyhOgEI=",
         "owner": "rycee",
         "repo": "nur-expressions",
-        "rev": "58bfa31fd4136a5b5fac268e93ff1789bd79d4a5",
+        "rev": "8f2693e1459d1a7a13aaa9fa702c210e9462b65b",
         "type": "gitlab"
       },
       "original": {
@@ -114,6 +114,27 @@
       "original": {
         "owner": "nix-community",
         "ref": "release-24.11",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager-unstable": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1739002622,
+        "narHash": "sha256-PtJV5OYQF7XO6XkDYypsYJS3+OsgYaYSmkO3I/A7lZo=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "947eef9e99c42346cf0aac2bebe1cd94924c173b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "master",
         "repo": "home-manager",
         "type": "github"
       }
@@ -294,11 +315,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1738824222,
-        "narHash": "sha256-U3SNq+waitGIotmgg/Et3J7o4NvUtP2gb2VhME5QXiw=",
+        "lastModified": 1738961098,
+        "narHash": "sha256-yWNBf6VDW38tl179FEuJ0qukthVfB02kv+mRsfUsWC0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "550e11f27ba790351d390d9eca3b80ad0f0254e7",
+        "rev": "a3eaf5e8eca7cab680b964138fb79073704aca75",
         "type": "github"
       },
       "original": {
@@ -341,6 +362,7 @@
         "flake-utils": "flake-utils",
         "gasp": "gasp",
         "home-manager": "home-manager",
+        "home-manager-unstable": "home-manager-unstable",
         "kanagawa-yazi": "kanagawa-yazi",
         "lix-module": "lix-module",
         "llakaLib": "llakaLib",
@@ -370,17 +392,16 @@
     "yazi-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1738169700,
-        "narHash": "sha256-1FZ8wcf2VVp6ZWY27vm1dUU1KAL32WwoYbNA/8RUAog=",
+        "lastModified": 1738930985,
+        "narHash": "sha256-axoMrOl0pdlyRgckFi4DiS+yBKAIHDhVeZQJINh8+wk=",
         "owner": "yazi-rs",
         "repo": "plugins",
-        "rev": "02d18be03812415097e83c6a912924560e4cec6d",
+        "rev": "07258518f3bffe28d87977bc3e8a88e4b825291b",
         "type": "github"
       },
       "original": {
         "owner": "yazi-rs",
         "repo": "plugins",
-        "rev": "02d18be03812415097e83c6a912924560e4cec6d",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -32,12 +32,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # BRING BACK IF YOU NEED UNSTABLE MODULES
-    # home-manager-unstable =
-    # {
-    #   url = "github:nix-community/home-manager/master";
-    #   inputs.nixpkgs.follows = "nixpkgs-unstable";
-    # };
+    home-manager-unstable =
+    {
+      url = "github:nix-community/home-manager/master";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
 
     kanagawa-yazi =
     {
@@ -79,8 +78,7 @@
 
     yazi-plugins =
     {
-      # TODO: unpin when https://nixpk.gs/pr-tracker.html?pr=380069 lands
-      url = "github:yazi-rs/plugins/02d18be03812415097e83c6a912924560e4cec6d";
+      url = "github:yazi-rs/plugins";
       flake = false;
     };
   };


### PR DESCRIPTION

Can't merge this until the relevant Home-Manager PR is merged, since it
currently has assertions for checking that plugins contain an `init.lua`.
And,  if I know Home-Manager, that'll be forever. I would patch it
manually, but the Home-Manager PR is broken right now -- left a comment.
When it gets fixed, I'll just point home-manager to their fork.
