### PR TITLE
hosts: set monitors.xml declaratively

### DIFF
--- a/config/gnome/scaling.nix
+++ b/config/gnome/scaling.nix
@@ -1,25 +1,12 @@
 { lib, config, ... }:
 
 {
-  # dconf options from nixos, NOT home-manager
+  # dconf options from nixos, NOT home-manager. Makes scaling also apply to login screen
   programs.dconf.profiles.gdm.databases = lib.singleton
   {
-    settings."org/gnome/desktop/interface" = # Scaling on login screen
+    settings."org/gnome/desktop/interface" =
     {
       scaling-factor = lib.gvariant.mkUint32 config.hostVars.scalingFactor;
     };
   };
-
-  hm.dconf.settings."org/gnome/desktop/interface" =
-  {
-    scaling-factor = lib.gvariant.mkUint32 config.hostVars.scalingFactor;
-  };
-
-  # Delete monitors.xml contents since it overrides any declarative scaling settings
-  hm.xdg.configFile."monitors.xml" =
-  {
-    text = "";
-    force = true;
-  };
-
 }

--- a/hosts/desktop/config/monitor.nix
+++ b/hosts/desktop/config/monitor.nix
@@ -1,0 +1,37 @@
+{ config, ... }:
+
+{
+  hm.xdg.configFile."monitors.xml" =
+  {
+    force = true;
+
+    text =
+    /* xml */
+    ''
+      <monitors version="2">
+        <configuration>
+          <layoutmode>physical</layoutmode>
+          <logicalmonitor>
+            <x>0</x>
+            <y>0</y>
+            <scale>${builtins.toString config.hostVars.scalingFactor}</scale>
+            <primary>yes</primary>
+            <monitor>
+              <monitorspec>
+                <connector>DP-1</connector>
+                <vendor>MSI</vendor>
+                <product>MSI MAG240CR</product>
+                <serial>BA5H011402092</serial>
+              </monitorspec>
+              <mode>
+                <width>1920</width>
+                <height>1080</height>
+                <rate>165.001</rate> <!-- Refresh rate -->
+              </mode>
+            </monitor>
+          </logicalmonitor>
+        </configuration>
+      </monitors>
+    '';
+  };
+}

--- a/hosts/framework/config/monitor.nix
+++ b/hosts/framework/config/monitor.nix
@@ -1,0 +1,37 @@
+{ config, ... }:
+
+{
+  hm.xdg.configFile."monitors.xml" =
+  {
+    force = true;
+
+    text =
+    /* xml */
+    ''
+      <monitors version="2">
+        <configuration>
+          <layoutmode>physical</layoutmode>
+          <logicalmonitor>
+            <x>0</x>
+            <y>0</y>
+            <scale>${builtins.toString config.hostVars.scalingFactor}</scale>
+            <primary>yes</primary>
+            <monitor>
+              <monitorspec>
+                <connector>eDP-1</connector>
+                <vendor>BOE</vendor>
+                <product>0x0bca</product>
+                <serial>0x00000000</serial>
+              </monitorspec>
+              <mode>
+                <width>2256</width>
+                <height>1504</height>
+                <rate>59.999</rate>
+              </mode>
+            </monitor>
+          </logicalmonitor>
+        </configuration>
+      </monitors>
+    '';
+  };
+}


### PR DESCRIPTION

Lets us set the refresh rate. We use this for the scaling factor as
well, keeping the gdm scaling to the gnome folder.
