### PR TITLE
starship: use heuristic for nix shells

### DIFF
--- a/apps/core/starship/disabled.nix
+++ b/apps/core/starship/disabled.nix
@@ -2,6 +2,5 @@
   hm.programs.starship.settings =
   {
     package.disabled = true;
-    nix_shell.disabled = true; # Breaks nix-direnv, and doesn't really work anyways
   };
 }

--- a/apps/core/starship/starship.nix
+++ b/apps/core/starship/starship.nix
@@ -58,4 +58,11 @@
     unloaded_msg = "UNLOADED";
   };
 
+  hm.programs.starship.settings.nix_shell =
+  {
+    disabled = false;
+    format = "[$symbol$state( \($name\))]($style)";
+    heuristic = true;
+  };
+
 }


### PR DESCRIPTION
Doesn't work right now because Kitty seems to always add itself from the nix store to $PATH, and the heuristic relies upon having no /nix/store stuff in your normal shell.